### PR TITLE
remove log4j from project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,18 +51,6 @@
 		<wicket.version>1.5.7</wicket.version>
 	</properties>
 	<dependencies>
-		<!-- LOGGING DEPENDENCIES - LOG4J -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.33</version>
-		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
-
 		<!-- JUNIT DEPENDENCY FOR TESTING -->
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
I see log4j configuration in this project, but it's never instantiated in the code itself.  This may cause downstream annoyance to other projects using this as a lib, or it might be nothing.  Either way, this addresses a security vulnerability, and the project still builds.