### PR TITLE
AART-2956 - Replace JDK 11 String.isBlank() with trim().isEmpty()

### DIFF
--- a/src/main/java/org/immregistries/vfa/connect/IISConnector.java
+++ b/src/main/java/org/immregistries/vfa/connect/IISConnector.java
@@ -1245,7 +1245,7 @@ public class IISConnector implements ConnectorInterface {
         // RXA-17
         sb.append("|");
         if (testEvent.getEvent().getVaccineMvx() != null
-            && !testEvent.getEvent().getVaccineMvx().isBlank()
+            && !testEvent.getEvent().getVaccineMvx().trim().isEmpty()
             && !"null".equals(testEvent.getEvent().getVaccineMvx())) {
           sb.append(testEvent.getEvent().getVaccineMvx() + "^"
               + testEvent.getEvent().getVaccineMvx() + "^MVX");


### PR DESCRIPTION
https://github.com/immregistries-internal/AART/issues/2956

Not using a Java 11 String method now.