### PR TITLE
Add limit argument to the split call on a segment string

### DIFF
--- a/src/main/java/org/immregistries/vfa/connect/IISConnector.java
+++ b/src/main/java/org/immregistries/vfa/connect/IISConnector.java
@@ -509,7 +509,7 @@ public class IISConnector implements ConnectorInterface {
         parseDebugLine = new ParseDebugLine(line);
         parseDebugLineList.add(parseDebugLine);
       }
-      String[] f = line.split("\\|");
+      String[] f = line.split("\\|", -1);
 
       if (f == null || f.length <= 1 || f[0] == null || f[0].length() != 3) {
         if (parseDebugLine != null) {
@@ -1392,7 +1392,7 @@ public class IISConnector implements ConnectorInterface {
     BufferedReader in = new BufferedReader(new StringReader(rsp));
     String line;
     while ((line = in.readLine()) != null) {
-      String[] f = line.split("\\|");
+      String[] f = line.split("\\|", -1);
       if (f == null || f.length <= 1 || f[0] == null || f[0].length() != 3) {
         continue;
       }


### PR DESCRIPTION
Encountered issue when parsing a message with empty fields, for example parsing the following segment
`OBX|11|TS|30980-7^Date Vaccine Due^LN|11||||||` using `String[] parsed = segment.split("\\|", -1);` will result in a parsed array with 5 elements. The rest of the parsing logic depends the OBX-5 field which has index **5** in the parsed array. The logic will fail with an array index out of bounds when trying to access `parsed[5]`.

This fix insures that parsed will have the right size for the provided segment, for example in this case it will have as many entries as necessary **11**, while most of them (from index 5 to the last index) will be empty strings, it will ensure that accessing `parsed[5]` doesn't result in an unintended exception.
