### PR TITLE
Changed Content-Type on SOAP request to match SOAP 1.2 standards.

### DIFF
--- a/src/main/java/org/immregistries/vfa/connect/IISConnector.java
+++ b/src/main/java/org/immregistries/vfa/connect/IISConnector.java
@@ -1327,8 +1327,8 @@ public class IISConnector implements ConnectorInterface {
     urlConn.setDoInput(true);
     urlConn.setDoOutput(true);
     urlConn.setUseCaches(false);
-    urlConn.setRequestProperty("Content-Type", "text/xml; charset=utf-8");
-    urlConn.setRequestProperty("SOAPAction", "\"http://tempuri.org/ExecuteHL7Message\"");
+    urlConn.setRequestProperty("Content-Type", "application/soap+xml; charset=utf-8");
+    urlConn.setRequestProperty("SOAPAction", "\"urn:cdc:iisb:2011:submitSingleMessage\"");
     printout = new DataOutputStream(urlConn.getOutputStream());
     StringWriter stringWriter = new StringWriter();
     PrintWriter out = new PrintWriter(stringWriter);

--- a/src/main/java/org/immregistries/vfa/connect/IISConnector.java
+++ b/src/main/java/org/immregistries/vfa/connect/IISConnector.java
@@ -1328,7 +1328,6 @@ public class IISConnector implements ConnectorInterface {
     urlConn.setDoOutput(true);
     urlConn.setUseCaches(false);
     urlConn.setRequestProperty("Content-Type", "application/soap+xml; charset=utf-8");
-    urlConn.setRequestProperty("SOAPAction", "\"urn:cdc:iisb:2011:submitSingleMessage\"");
     printout = new DataOutputStream(urlConn.getOutputStream());
     StringWriter stringWriter = new StringWriter();
     PrintWriter out = new PrintWriter(stringWriter);


### PR DESCRIPTION
SOAP 1.2 standards specify that the content type should be set to "application/soap+xml"

I also fixed the soap action, which should reference the URI and action from the WSDL. 

here is a site where a developer gives two examples showing the difference: 
https://www.herongyang.com/Web-Services/Perl-SOAP-1-2-Request-Differences-SOAP-1-1-and-1-2.html