### PR TITLE
Fixed Accept Header for communication with SOAP endpoints

### DIFF
--- a/src/main/java/org/immregistries/vfa/connect/ICEConnector.java
+++ b/src/main/java/org/immregistries/vfa/connect/ICEConnector.java
@@ -146,6 +146,7 @@ public class ICEConnector implements ConnectorInterface
       urlConn.setRequestProperty("Content-Type", "text/xml; charset=\"utf-8\"");
       urlConn.setRequestProperty("SoapAction",
           "http://www.omg.org/spec/CDSS/201105/dssWsdl:operation:evaluateAtSpecifiedTime");
+      urlConn.setRequestProperty("Accept", "text/xml");
 
       DataOutputStream printout = new DataOutputStream(urlConn.getOutputStream());
       printout.writeBytes(makeRequest(testCase));

--- a/src/main/java/org/immregistries/vfa/connect/IISConnector.java
+++ b/src/main/java/org/immregistries/vfa/connect/IISConnector.java
@@ -1328,6 +1328,7 @@ public class IISConnector implements ConnectorInterface {
     urlConn.setDoOutput(true);
     urlConn.setUseCaches(false);
     urlConn.setRequestProperty("Content-Type", "application/soap+xml; charset=utf-8");
+    urlConn.setRequestProperty("Accept", "application/soap+xml");
     printout = new DataOutputStream(urlConn.getOutputStream());
     StringWriter stringWriter = new StringWriter();
     PrintWriter out = new PrintWriter(stringWriter);

--- a/src/main/java/org/immregistries/vfa/connect/LSVFConnector.java
+++ b/src/main/java/org/immregistries/vfa/connect/LSVFConnector.java
@@ -192,6 +192,7 @@ public class LSVFConnector implements ConnectorInterface
       urlConn.setDoOutput(true);
       urlConn.setUseCaches(true);
       urlConn.setRequestProperty("Content-Type", "text/xml; charset=\"utf-8\"");
+      urlConn.setRequestProperty("Accept", "text/xml");
       urlConn.connect();
 
       InputStreamReader input = null;

--- a/src/main/java/org/immregistries/vfa/connect/SWPConnector.java
+++ b/src/main/java/org/immregistries/vfa/connect/SWPConnector.java
@@ -231,6 +231,7 @@ public class SWPConnector implements ConnectorInterface
       urlConn.setDoOutput(true);
       urlConn.setUseCaches(true);
       urlConn.setRequestProperty("Content-Type", "text/xml; charset=\"utf-8\"");
+      urlConn.setRequestProperty("Accept", "text/xml");
       printOut = new DataOutputStream(urlConn.getOutputStream());
       StringBuilder sb = new StringBuilder();
 


### PR DESCRIPTION
Changed Accept header from the default `Accept: text/html, image/gif, image/jpeg, *; q=.2, /; q=.2` to the accurate ones for SOAP Connectors